### PR TITLE
Fix bug in SplitFileName()

### DIFF
--- a/ANSIC.lby
+++ b/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<Library Version="0.14.3" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<Library Version="0.14.4" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File>RevisionHistory.txt</File>
     <File>LICENSE.txt</File>

--- a/RevisionHistory.txt
+++ b/RevisionHistory.txt
@@ -1,3 +1,4 @@
+0.14.4 - Fix bug in SplitFileName()
 0.14.3 - Add support for strptime in GCC6
 0.14.2 - Add stringpTime() and stringfTime()
 0.14.1 - Add formatString()

--- a/SplitFileName.c
+++ b/SplitFileName.c
@@ -37,7 +37,7 @@ unsigned long SplitFileName(unsigned long pFileName, unsigned long pName, unsign
 	if(extLength > 0)
 		extLength = extLength - 1;
 	
-	STRING tempString[strLength];
+	STRING tempString[strLength+1];
 	
 	memcpy(&tempString, (void*)pFileName, strLength+1);
 	


### PR DESCRIPTION
# What

Increased memory size of temporary string buffer by 1 byte in SplitFileName function. In some cases*, the resulting file name had garbage data in it rather than the correct string text.

*The exact conditions for when the behavior would happen are unknown. Its possible it has to do with whether the byte immediately following the temp stack variable was \0 or not, but this is just a guess.

# Why

Previously the function could produce undesired behavior
