### PR TITLE
Fix workflow input: rename build-mode to build_mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   workflow_dispatch:
     inputs:
-      build-mode:
+      build_mode:
         description: 'Build mode'
         required: false
         default: 'Build'
@@ -50,7 +50,7 @@ jobs:
           exe-path:   ${{ steps.find-as.outputs.exe-path }}
           project:    ${{ env.PROJECT }}
           config:     Intel
-          build-mode: ${{ inputs.build-mode || 'Build' }}
+          build-mode: ${{ inputs.build_mode || 'Build' }}
 
       - name: Build ARM
         uses: loupeteam/br-actions/build-as-project@v1
@@ -58,7 +58,7 @@ jobs:
           exe-path:   ${{ steps.find-as.outputs.exe-path }}
           project:    ${{ env.PROJECT }}
           config:     ARM
-          build-mode: ${{ inputs.build-mode || 'Build' }}
+          build-mode: ${{ inputs.build_mode || 'Build' }}
 
       - name: Upload build diagnostics
         if: always()


### PR DESCRIPTION
## What
Renames the workflow_dispatch input `build-mode` to `build_mode` and updates the dot-notation reference accordingly.

## Why
Hyphenated input names get parsed as subtraction in ${{ inputs.<name> }} expressions — `inputs.build-mode` is interpreted as `inputs.build` minus `mode`, which always evaluates to null. Combined with the `|| 'Build'` fallback, manual `workflow_dispatch` runs effectively ignored the user's selection and always built as 'Build'. PR triggers were unaffected.

Snake_case lets the dot-notation reference work correctly. The `|| 'Build'` fallback continues to handle the missing-inputs context on `pull_request` triggers.

Same fix landed across the AS6 sweep so all repos converge on the same template.

Caught by Copilot review on a sibling repo's workflow.